### PR TITLE
[MERCHATS-14] Endpoints para cadastrar permissão e conceder permissão para identidade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 .PHONY: install reset-db run-playground test-playground
 
 install:
-	pip install -e .
 	pip install -e .[dev]
-	pip install -e .[test]
-	pip install -e .[ci]
-	pip install -e .[sqla]
 
 run-playground:
 	python playground/main.py

--- a/keyloop/__init__.py
+++ b/keyloop/__init__.py
@@ -5,7 +5,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import aslist
 from zope.interface.adapter import AdapterRegistry
 
-from keyloop.interfaces import auth_session, identity, permission, permission_grant
+from keyloop.interfaces import auth_session, identity, permission
 
 logger = logging.getLogger(__name__)
 

--- a/keyloop/__init__.py
+++ b/keyloop/__init__.py
@@ -51,18 +51,6 @@ def _register_adapters(config):
         )
         logger.debug("Registered IPermissionSource adapter for realm '%s'", realm)
 
-    perm_grant_adapters = aslist(settings["keyloop.perm_grant_sources"])
-    for adapter_description in perm_grant_adapters:
-        realm, perm_grant_source_name = adapter_description.split(":")
-
-        adapter_registry.register(
-            [permission_grant.IPermissionGrant],
-            permission_grant.IPermissionGrantSource,
-            realm,
-            config.maybe_dotted(perm_grant_source_name)
-        )
-        logger.debug("Registered IPermissionGrantSource adapter for realm '%s'", realm)
-
     config.registry.settings["keyloop_adapters"] = adapter_registry
 
 

--- a/keyloop/__init__.py
+++ b/keyloop/__init__.py
@@ -5,7 +5,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.settings import aslist
 from zope.interface.adapter import AdapterRegistry
 
-from keyloop.interfaces import auth_session, identity, permission
+from keyloop.interfaces import auth_session, identity, permission, permission_grant
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,18 @@ def _register_adapters(config):
             config.maybe_dotted(permission_source_name)
         )
         logger.debug("Registered IPermissionSource adapter for realm '%s'", realm)
+
+    perm_grant_adapters = aslist(settings["keyloop.perm_grant_sources"])
+    for adapter_description in perm_grant_adapters:
+        realm, perm_grant_source_name = adapter_description.split(":")
+
+        adapter_registry.register(
+            [permission_grant.IPermissionGrant],
+            permission_grant.IPermissionGrantSource,
+            realm,
+            config.maybe_dotted(perm_grant_source_name)
+        )
+        logger.debug("Registered IPermissionGrantSource adapter for realm '%s'", realm)
 
     config.registry.settings["keyloop_adapters"] = adapter_registry
 

--- a/keyloop/api/v1/auth_session.py
+++ b/keyloop/api/v1/auth_session.py
@@ -7,7 +7,6 @@ from grip.context import SimpleBaseFactory
 from grip.decorator import view as grip_view
 from grip.resource import BaseResource, default_error_handler
 from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed
-
 from keyloop.schemas.auth_session import AuthSessionSchema
 from keyloop.schemas.path import BasePathSchema
 

--- a/keyloop/api/v1/exceptions.py
+++ b/keyloop/api/v1/exceptions.py
@@ -10,3 +10,13 @@ class IdentityAlreadyExists(Exception):
 class AuthenticationFailed(Exception):
     """Raise an error if an user pass a wrong password"""
     pass
+
+
+class PermissionAlreadyExists(Exception):
+    """Permission already exists with specific name."""
+    pass
+
+
+class PermissionGrantAlreadyExists(Exception):
+    """Permission-Identity association already exists."""
+    pass

--- a/keyloop/api/v1/exceptions.py
+++ b/keyloop/api/v1/exceptions.py
@@ -23,6 +23,8 @@ class PermissionAlreadyExists(Exception):
     pass
 
 
-class PermissionGrantAlreadyExists(Exception):
+class PermissionAlreadyGranted(Exception):
     """Permission-Identity association already exists."""
     pass
+
+

--- a/keyloop/api/v1/exceptions.py
+++ b/keyloop/api/v1/exceptions.py
@@ -2,6 +2,7 @@ class IdentityNotFound(Exception):
     """Raise an error if identity has not been found"""
     pass
 
+
 class IdentityAlreadyExists(Exception):
     """Raise an error if identity already exists"""
     pass
@@ -9,6 +10,11 @@ class IdentityAlreadyExists(Exception):
 
 class AuthenticationFailed(Exception):
     """Raise an error if an user pass a wrong password"""
+    pass
+
+
+class PermissionNotFound(Exception):
+    """Permission not found."""
     pass
 
 

--- a/keyloop/api/v1/identity.py
+++ b/keyloop/api/v1/identity.py
@@ -89,7 +89,7 @@ class IdentityResource(BaseResource):
     def get(self):
         """ Return identity info + permissions """
         try:
-            return self.request.identity_provider.get(self.request.validated['path']['id'])
+            return self.request.identity_provider.get(uuid=self.request.validated['path']['id'])
 
         except IdentityNotFound:
             self.request.errors.add(

--- a/keyloop/api/v1/identity.py
+++ b/keyloop/api/v1/identity.py
@@ -89,7 +89,7 @@ class IdentityResource(BaseResource):
     def get(self):
         """ Return identity info + permissions """
         try:
-            return self.request.identity_provider.get(uuid=self.request.validated['path']['id'])
+            return self.request.identity_provider.get_by(uuid=self.request.validated['path']['id'])
 
         except IdentityNotFound:
             self.request.errors.add(

--- a/keyloop/api/v1/permission-grant.py
+++ b/keyloop/api/v1/permission-grant.py
@@ -1,0 +1,47 @@
+import logging
+
+import marshmallow
+from cornice.resource import resource
+from pyramid.security import Everyone, Allow
+
+from grip.context import SimpleBaseFactory
+from grip.decorator import view as grip_view
+from grip.resource import BaseResource, default_error_handler
+from keyloop.schemas.path import BasePathSchema
+from keyloop.schemas.permission import PermissionGrantSchema
+
+logger = logging.getLogger(__name__)
+
+
+class PermissionGrantContext(SimpleBaseFactory):
+    def __acl__(self):
+        return [(Allow, Everyone, 'edit')]
+
+
+class CollectionPostSchema(marshmallow.Schema):
+    path = marshmallow.fields.Nested(BasePathSchema)
+    body = marshmallow.fields.Nested(PermissionGrantSchema)
+
+
+collection_post_response_schemas = {
+    200: PermissionGrantSchema
+}
+
+
+@resource(
+    collection_path="/realms/{realm_slug}/identities/{id}/permissions",
+    path="/realms/{realm_slug}/identities/{id}/permissions/{perm_grant_id}",
+    content_type="application/vnd.api+json",
+    factory=PermissionGrantContext,
+)
+class PermissionGrantResource(BaseResource):
+
+    @grip_view(schema=CollectionPostSchema,
+               response_schema=collection_post_response_schemas,
+               error_handler=default_error_handler)
+    def collection_post(self):
+        validated = self.request.validated
+        identity = self.request.identity_provider.get(validated["path"]["id"])
+        permission = self.request.permission_provider.get(name=validated["body"]["perm_name"])
+        perm_grant = self.request.perm_grant_provider.create(permission.uuid, identity.id)
+        return perm_grant

--- a/keyloop/api/v1/permission.py
+++ b/keyloop/api/v1/permission.py
@@ -1,0 +1,45 @@
+import logging
+
+import marshmallow
+from cornice.resource import resource
+from pyramid.security import Everyone, Allow
+
+from grip.context import SimpleBaseFactory
+from grip.decorator import view as grip_view
+from grip.resource import BaseResource, default_error_handler
+from keyloop.schemas.path import BasePathSchema
+from keyloop.schemas.permission import PermissionSchema
+
+logger = logging.getLogger(__name__)
+
+
+class PermissionContext(SimpleBaseFactory):
+    def __acl__(self):
+        return [(Allow, Everyone, 'edit')]
+
+
+class CollectionPostPermissionSchema(marshmallow.Schema):
+    path = marshmallow.fields.Nested(BasePathSchema)
+    body = marshmallow.fields.Nested(PermissionSchema)
+
+
+collection_post_response_schemas = {
+    200: PermissionSchema(),
+}
+
+
+@resource(
+    collection_path="/realms/{realm_slug}/permissions",
+    path="/realms/{realm_slug}/permissions/{id}",
+    content_type="application/vnd.api+json",
+    factory=PermissionContext,
+)
+class PermissionResource(BaseResource):
+
+    @grip_view(schema=CollectionPostPermissionSchema, response_schema=collection_post_response_schemas,
+               error_handler=default_error_handler)
+    def collection_post(self):
+        breakpoint()
+        validated = self.request.validated["body"]
+        permission = self.request.permission_provider.create(validated["name"], validated["description"])
+        return permission

--- a/keyloop/api/v1/permission.py
+++ b/keyloop/api/v1/permission.py
@@ -39,7 +39,6 @@ class PermissionResource(BaseResource):
     @grip_view(schema=CollectionPostPermissionSchema, response_schema=collection_post_response_schemas,
                error_handler=default_error_handler)
     def collection_post(self):
-        breakpoint()
         validated = self.request.validated["body"]
         permission = self.request.permission_provider.create(validated["name"], validated["description"])
         return permission

--- a/keyloop/api/v1/permission.py
+++ b/keyloop/api/v1/permission.py
@@ -8,6 +8,7 @@ from grip.context import SimpleBaseFactory
 from grip.decorator import view as grip_view
 from grip.resource import BaseResource, default_error_handler
 from keyloop.api.v1.exceptions import PermissionAlreadyExists
+from keyloop.schemas.error import ErrorSchema
 from keyloop.schemas.path import BasePathSchema
 from keyloop.schemas.permission import PermissionSchema
 
@@ -26,6 +27,7 @@ class CollectionPostSchema(marshmallow.Schema):
 
 collection_post_response_schemas = {
     200: PermissionSchema(),
+    400: ErrorSchema()
 }
 
 

--- a/keyloop/api/v1/permission.py
+++ b/keyloop/api/v1/permission.py
@@ -10,10 +10,11 @@ from grip.resource import BaseResource, default_error_handler
 from keyloop.api.v1.exceptions import PermissionAlreadyExists
 from keyloop.schemas.error import ErrorSchema
 from keyloop.schemas.path import BasePathSchema
-from keyloop.schemas.permission import PermissionSchema
+from keyloop.schemas.permission import PermissionSchema, PermissionQueryStringSchema, PermissionsListSchema
 
 logger = logging.getLogger(__name__)
 
+MAX_ROWS_PER_PAGE = 30
 
 class PermissionContext(SimpleBaseFactory):
     def __acl__(self):
@@ -22,12 +23,21 @@ class PermissionContext(SimpleBaseFactory):
 
 class CollectionPostSchema(marshmallow.Schema):
     path = marshmallow.fields.Nested(BasePathSchema)
-    body = marshmallow.fields.Nested(PermissionSchema)
+    body = marshmallow.fields.Nested(PermissionSchema(exclude=['document_meta']))
+
+
+class CollectionGetSchema(marshmallow.Schema):
+    path = marshmallow.fields.Nested(BasePathSchema)
+    querystring = marshmallow.fields.Nested(PermissionQueryStringSchema)
 
 
 collection_post_response_schemas = {
     200: PermissionSchema(),
     400: ErrorSchema()
+}
+
+collection_get_response_schemas = {
+    200: PermissionsListSchema(),
 }
 
 
@@ -53,3 +63,13 @@ class PermissionResource(BaseResource):
                 name="name",
                 description=f"Existent permission with name: {params['name']}"
             )
+
+    @grip_view(schema=CollectionGetSchema, response_schema=collection_get_response_schemas)
+    def collection_get(self):
+        params = self.request.validated["querystring"]
+        page = params['page'] if 'page' in params else 1
+        limit = params['limit'] if 'limit' in params else MAX_ROWS_PER_PAGE
+
+        # TODO: Adjust the grip for mount the pages link. The marshmallow json-api doesn't do it yet
+        return self.request.permission_provider.list(page, limit)
+

--- a/keyloop/api/v1/permission_grant.py
+++ b/keyloop/api/v1/permission_grant.py
@@ -64,7 +64,6 @@ class PermissionGrantResource(BaseResource):
                 name='perm_name',
                 description='Permission not found'
             )
-            self.request.errors.status = 400
             return
 
         try:
@@ -75,7 +74,6 @@ class PermissionGrantResource(BaseResource):
                 name='perm_name',
                 description='Permission already granted to identity'
             )
-            self.request.errors.status = 400
             return
 
         return permission

--- a/keyloop/api/v1/permission_grant.py
+++ b/keyloop/api/v1/permission_grant.py
@@ -26,7 +26,7 @@ class CollectionPostSchema(marshmallow.Schema):
 
 
 collection_post_response_schemas = {
-    200: PermissionSchema,
+    200: PermissionSchema(),
     404: ErrorSchema(),
     400: ErrorSchema()
 }

--- a/keyloop/api/v1/permission_grant.py
+++ b/keyloop/api/v1/permission_grant.py
@@ -60,7 +60,7 @@ class PermissionGrantResource(BaseResource):
             permission = self.request.permission_provider.get_by(name=validated["body"]["perm_name"])
         except PermissionNotFound:
             self.request.errors.add(
-                location='path',
+                location='body',
                 name='perm_name',
                 description='Permission not found'
             )
@@ -71,10 +71,11 @@ class PermissionGrantResource(BaseResource):
             self.request.identity_provider.grant_permission(permission, identity)
         except PermissionAlreadyGranted:
             self.request.errors.add(
-                location='path',
+                location='body',
                 name='perm_name',
-                description='Permission already granted to identity.'
+                description='Permission already granted to identity'
             )
             self.request.errors.status = 400
+            return
 
         return permission

--- a/keyloop/ext/sqla/__init__.py
+++ b/keyloop/ext/sqla/__init__.py
@@ -1,5 +1,6 @@
-from keyloop.ext.sqla.identity import IdentitySource
 from keyloop.ext.sqla.auth_session import AuthSessionSource
+from keyloop.ext.sqla.identity import IdentitySource
+from keyloop.ext.sqla.permission import PermissionSource
 
 
 def setup_models(config, session, params):

--- a/keyloop/ext/sqla/identity.py
+++ b/keyloop/ext/sqla/identity.py
@@ -58,22 +58,19 @@ class IdentitySource:
 
     @singletonmethod
     def get_by(self, **kwargs):
-        if 'username' in kwargs.keys():
-            try:
-                return (self.session
-                        .query(self.model)
-                        .filter(self.model.username == kwargs['username'], self.model.active == True)
-                        .one())
-            except NoResultFound:
-                raise IdentityNotFound
-        elif 'uuid' in kwargs.keys():
-            try:
-                return (self.session
-                        .query(self.model)
-                        .filter(self.model.id == kwargs['uuid'], self.model.active == True)
-                        .one())
-            except NoResultFound:
-                raise IdentityNotFound
+        active_users = self.session.query(self.model).filter(self.model.active == True)
+
+        if 'username' in kwargs:
+            query = active_users.filter_by(username=kwargs['username'])
+        elif 'uuid' in kwargs:
+            query = active_users.filter_by(id=kwargs['uuid'])
+        else:
+            return
+
+        try:
+            return query.one()
+        except NoResultFound:
+            raise IdentityNotFound()
 
     @singletonmethod
     def create(self, username, password, name=None):

--- a/keyloop/ext/sqla/identity.py
+++ b/keyloop/ext/sqla/identity.py
@@ -1,6 +1,5 @@
-import cryptacular.bcrypt
+import cryptacular
 import sqlalchemy as sa
-import transaction
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship, backref
@@ -8,15 +7,13 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy_utils.types.uuid import UUIDType
 from zope.interface import implementer
 
-import uuid
-
 from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed, IdentityAlreadyExists
 from keyloop.ext.sqla.auth_session import password_check
 from keyloop.interfaces.identity import IIdentity, IIdentitySource
 from keyloop.ext.utils.decorators import singleton, singletonmethod
+from keyloop.utils import generate_uuid
 
 bcrypt = cryptacular.bcrypt.BCRYPTPasswordManager()
-
 
 
 @implementer(IIdentity)
@@ -25,7 +22,7 @@ class Identity:
 
     @declared_attr
     def id(self):
-        return sa.Column(UUIDType, primary_key=True, default=uuid.uuid4)
+        return sa.Column(UUIDType, primary_key=True, default=generate_uuid)
 
     @declared_attr
     def username(self):

--- a/keyloop/ext/sqla/identity.py
+++ b/keyloop/ext/sqla/identity.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy_utils.types.uuid import UUIDType
 from zope.interface import implementer
 
-from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed, IdentityAlreadyExists
+from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed, IdentityAlreadyExists, PermissionAlreadyGranted
 from keyloop.ext.sqla.auth_session import password_check
 from keyloop.ext.utils.decorators import singleton, singletonmethod
 from keyloop.interfaces.identity import IIdentity, IIdentitySource
@@ -122,4 +122,6 @@ class IdentitySource:
 
     @singletonmethod
     def grant_permission(self, permission, identity):
+        if permission in identity.permissions:
+            raise PermissionAlreadyGranted()
         identity.permissions.append(permission)

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -1,0 +1,68 @@
+import sqlalchemy as sa
+import transaction
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy_utils import UUIDType
+from zope.interface import implementer
+
+from keyloop.ext.utils.decorators import singleton, singletonmethod
+from keyloop.interfaces.permission import IPermission, IPermissionSource
+from keyloop.utils import generate_uuid
+
+
+class IdentityPermissionAssociation:
+    __tablename__ = 'identity_permission_association'
+
+    @declared_attr
+    def id(self):
+        return sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    @declared_attr
+    def identity_id(self):
+        return sa.Column('identity_id', sa.Integer, sa.ForeignKey('identity.id'))
+
+    @declared_attr
+    def permission_id(self):
+        return sa.Column('permission_id', sa.Integer, sa.ForeignKey('permission.id'))
+
+
+@implementer(IPermission)
+@singleton
+class Permission:
+    __tablename__ = 'permission'
+
+    @declared_attr
+    def id(self):
+        return sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    @declared_attr
+    def uuid(self):
+        return sa.Column(UUIDType, default=generate_uuid)
+
+    @declared_attr
+    def name(self):
+        return sa.Column(sa.String, unique=True, index=True)
+
+    @declared_attr
+    def description(self):
+        return sa.Column(sa.String, nullable=False)
+
+
+@implementer(IPermissionSource)
+@singleton
+class PermissionSource:
+    def __init__(self, session, model):
+        self.model = model
+        self.session = session
+
+    @singletonmethod
+    def get(self, name):
+        return self.session.query(self.model).filter(name=name).one()
+
+    @singletonmethod
+    def create(self, name, description):
+        breakpoint()
+        permission = self.model(name=name, description=description)
+        self.session.add(permission)
+
+        transaction.commit()
+        return self.get(name)

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -48,7 +48,6 @@ from keyloop.utils import generate_uuid
 
 
 @implementer(IPermission)
-@singleton
 class Permission:
     __tablename__ = 'permission'
 

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy_pagination import paginate
 from sqlalchemy_utils import UUIDType
 from zope.interface import implementer
 
@@ -63,3 +64,17 @@ class PermissionSource:
             raise PermissionAlreadyExists()
 
         return permission
+
+    @singletonmethod
+    def list(self, page, limit):
+        permissions = paginate(self.session.query(self.model), page, limit)
+        params = {
+            'items': permissions.items,
+            'document_meta': {
+                'prev': permissions.previous_page,
+                'next': permissions.next_page,
+                'page': permissions.pages,
+                'total': permissions.total
+            }
+        }
+        return params

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -1,28 +1,50 @@
 import sqlalchemy as sa
-import transaction
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy_utils import UUIDType
 from zope.interface import implementer
 
+from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionNotFound
 from keyloop.ext.utils.decorators import singleton, singletonmethod
 from keyloop.interfaces.permission import IPermission, IPermissionSource
 from keyloop.utils import generate_uuid
 
 
-class IdentityPermissionAssociation:
-    __tablename__ = 'identity_permission_association'
+# @implementer(IPermissionGrantSource)
+# @singleton
+# class PermissionGrantSource:
+#
+#     def __init__(self, session, model):
+#         self.model = model
+#         self.session = session
+#
+#     def grant_permission(cls, permission_id, identity_id):
+#         perm_ident_assoc = (permission_id, identity_id)
+#         if perm_ident_assoc in cls.PERM_IDENT_ASSOCIATIONS:
+#             raise PermissionGrantAlreadyExists
+#
+#         permission_grant = cls(*perm_ident_assoc)
+#         cls.PERMISSION_GRANTS.update({permission_grant.uuid: permission_grant.__dict__})
+#         cls.PERM_IDENT_ASSOCIATIONS.add(perm_ident_assoc)
+#         return permission_grant
 
-    @declared_attr
-    def id(self):
-        return sa.Column(sa.Integer, autoincrement=True, primary_key=True)
 
-    @declared_attr
-    def identity_id(self):
-        return sa.Column('identity_id', sa.Integer, sa.ForeignKey('identity.id'))
-
-    @declared_attr
-    def permission_id(self):
-        return sa.Column('permission_id', sa.Integer, sa.ForeignKey('permission.id'))
+# @implementer(IPermissionGrant)
+# class PermissionGrant:
+#     __tablename__ = 'permission_grant'
+#
+#     @declared_attr
+#     def id(self):
+#         return sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+#
+#     @declared_attr
+#     def identity_id(self):
+#         return sa.Column('identity_id', sa.Integer, sa.ForeignKey('identity.id'))
+#
+#     @declared_attr
+#     def permission_id(self):
+#         return sa.Column('permission_id', sa.Integer, sa.ForeignKey('permission.id'))
 
 
 @implementer(IPermission)
@@ -55,13 +77,26 @@ class PermissionSource:
         self.session = session
 
     @singletonmethod
-    def get(self, name):
-        return self.session.query(self.model).filter_by(name=name).one()
+    def get_by(self, **kwargs):
+        if 'name' in kwargs.keys():
+            try:
+                return self.session.query(self.model).filter_by(name=kwargs['name']).one()
+            except NoResultFound:
+                raise PermissionNotFound()
+        elif 'uuid' in kwargs.keys():
+            try:
+                return self.session.query(self.model).filter_by(uuid=kwargs['uuid']).one()
+            except NoResultFound:
+                raise PermissionNotFound()
 
     @singletonmethod
     def create(self, name, description):
         permission = self.model(name=name, description=description)
         self.session.add(permission)
 
-        transaction.commit()
-        return self.get(name)
+        try:
+            self.session.flush()
+        except IntegrityError:
+            raise PermissionAlreadyExists()
+
+        return permission

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -11,42 +11,6 @@ from keyloop.interfaces.permission import IPermission, IPermissionSource
 from keyloop.utils import generate_uuid
 
 
-# @implementer(IPermissionGrantSource)
-# @singleton
-# class PermissionGrantSource:
-#
-#     def __init__(self, session, model):
-#         self.model = model
-#         self.session = session
-#
-#     def grant_permission(cls, permission_id, identity_id):
-#         perm_ident_assoc = (permission_id, identity_id)
-#         if perm_ident_assoc in cls.PERM_IDENT_ASSOCIATIONS:
-#             raise PermissionGrantAlreadyExists
-#
-#         permission_grant = cls(*perm_ident_assoc)
-#         cls.PERMISSION_GRANTS.update({permission_grant.uuid: permission_grant.__dict__})
-#         cls.PERM_IDENT_ASSOCIATIONS.add(perm_ident_assoc)
-#         return permission_grant
-
-
-# @implementer(IPermissionGrant)
-# class PermissionGrant:
-#     __tablename__ = 'permission_grant'
-#
-#     @declared_attr
-#     def id(self):
-#         return sa.Column(sa.Integer, autoincrement=True, primary_key=True)
-#
-#     @declared_attr
-#     def identity_id(self):
-#         return sa.Column('identity_id', sa.Integer, sa.ForeignKey('identity.id'))
-#
-#     @declared_attr
-#     def permission_id(self):
-#         return sa.Column('permission_id', sa.Integer, sa.ForeignKey('permission.id'))
-
-
 @implementer(IPermission)
 class Permission:
     __tablename__ = 'permission'

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -56,11 +56,10 @@ class PermissionSource:
 
     @singletonmethod
     def get(self, name):
-        return self.session.query(self.model).filter(name=name).one()
+        return self.session.query(self.model).filter_by(name=name).one()
 
     @singletonmethod
     def create(self, name, description):
-        breakpoint()
         permission = self.model(name=name, description=description)
         self.session.add(permission)
 

--- a/keyloop/ext/sqla/permission.py
+++ b/keyloop/ext/sqla/permission.py
@@ -42,16 +42,17 @@ class PermissionSource:
 
     @singletonmethod
     def get_by(self, **kwargs):
-        if 'name' in kwargs.keys():
-            try:
-                return self.session.query(self.model).filter_by(name=kwargs['name']).one()
-            except NoResultFound:
-                raise PermissionNotFound()
-        elif 'uuid' in kwargs.keys():
-            try:
-                return self.session.query(self.model).filter_by(uuid=kwargs['uuid']).one()
-            except NoResultFound:
-                raise PermissionNotFound()
+        if 'name' in kwargs:
+            query = self.session.query(self.model).filter_by(name=kwargs['name'])
+        elif 'uuid' in kwargs:
+            query = self.session.query(self.model).filter_by(uuid=kwargs['uuid'])
+        else:
+            return
+
+        try:
+            return query.one()
+        except NoResultFound:
+            raise PermissionNotFound()
 
     @singletonmethod
     def create(self, name, description):

--- a/keyloop/interfaces/identity.py
+++ b/keyloop/interfaces/identity.py
@@ -30,3 +30,6 @@ class IIdentitySource(Interface):
 
     def update(identity_id: str, params: dict):
         pass
+
+    def grant_permission(permission, identity):
+        pass

--- a/keyloop/interfaces/permission.py
+++ b/keyloop/interfaces/permission.py
@@ -12,7 +12,7 @@ class IPermissionSource(Interface):
     """Marker interface for callables that retrieve a Permission object given a name/uuid
     """
 
-    def get(name: str) -> IPermission:
+    def get_by(name: str, uuid: str) -> IPermission:
         pass
 
     def create(self, name: str, description: T.Optional[str]):

--- a/keyloop/interfaces/permission.py
+++ b/keyloop/interfaces/permission.py
@@ -1,0 +1,19 @@
+import typing as T
+
+from zope.interface import Attribute, Interface
+
+
+class IPermission(Interface):
+    name = Attribute('Unique string used for identifying permission.')
+    description = Attribute('Detailed information about the permission.')
+
+
+class IPermissionSource(Interface):
+    """Marker interface for callables that retrieve a Permission object given a name/uuid
+    """
+
+    def get(name: str) -> IPermission:
+        pass
+
+    def create(self, name: str, description: T.Optional[str]):
+        pass

--- a/keyloop/interfaces/permission.py
+++ b/keyloop/interfaces/permission.py
@@ -17,3 +17,6 @@ class IPermissionSource(Interface):
 
     def create(self, name: str, description: T.Optional[str]):
         pass
+
+    def list(self, page: int, limit: int):
+        pass

--- a/keyloop/interfaces/permission_grant.py
+++ b/keyloop/interfaces/permission_grant.py
@@ -1,0 +1,17 @@
+from zope.interface import Attribute, Interface
+
+
+class IPermissionGrant(Interface):
+    permission_id = Attribute('FK for Permission model.')
+    identity_id = Attribute('FK for Identity model')
+
+
+class IPermissionGrantSource(Interface):
+    """Marker interface for callables that retrieve a PermissionGrant object given a uuid
+    """
+
+    def get(uuid: str) -> IPermissionGrant:
+        pass
+
+    def create(self, permission_id: str, identity_id: str):
+        pass

--- a/keyloop/schemas/identity.py
+++ b/keyloop/schemas/identity.py
@@ -1,9 +1,6 @@
-from enum import Enum
-
-import marshmallow
 import marshmallow_jsonapi
 from marshmallow import fields
-from marshmallow_enum import EnumField
+
 
 class BaseIdentitySchema(marshmallow_jsonapi.Schema):
     class Meta:

--- a/keyloop/schemas/path.py
+++ b/keyloop/schemas/path.py
@@ -5,7 +5,6 @@ import marshmallow
 from keyloop.interfaces.auth_session import IAuthSession, IAuthSessionSource
 from keyloop.interfaces.identity import IIdentity, IIdentitySource
 from keyloop.interfaces.permission import IPermission, IPermissionSource
-from keyloop.interfaces.permission_grant import IPermissionGrant, IPermissionGrantSource
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +22,8 @@ class BasePathSchema(marshmallow.Schema):
         identity_provider = registry.lookup([IIdentity], IIdentitySource, value)
         auth_session = registry.lookup([IAuthSession], IAuthSessionSource, value)
         permission_provider = registry.lookup([IPermission], IPermissionSource, value)
-        perm_grant_provider = registry.lookup([IPermissionGrant], IPermissionGrantSource, value)
 
-        if not (identity_provider or auth_session or permission_provider or perm_grant_provider):
+        if not (identity_provider or auth_session or permission_provider):
             request.errors.add(
                 location='path',
                 name='realm_slug',
@@ -38,8 +36,3 @@ class BasePathSchema(marshmallow.Schema):
         request.identity_provider = identity_provider
         request.auth_session = auth_session
         request.permission_provider = permission_provider
-        request.perm_grant_provider = perm_grant_provider
-
-
-class PermissionGrantPathSchema(BasePathSchema):
-    perm_grant_id = marshmallow.fields.UUID()

--- a/keyloop/schemas/path.py
+++ b/keyloop/schemas/path.py
@@ -5,6 +5,7 @@ import marshmallow
 from keyloop.interfaces.auth_session import IAuthSession, IAuthSessionSource
 from keyloop.interfaces.identity import IIdentity, IIdentitySource
 from keyloop.interfaces.permission import IPermission, IPermissionSource
+from keyloop.interfaces.permission_grant import IPermissionGrant, IPermissionGrantSource
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,9 @@ class BasePathSchema(marshmallow.Schema):
         identity_provider = registry.lookup([IIdentity], IIdentitySource, value)
         auth_session = registry.lookup([IAuthSession], IAuthSessionSource, value)
         permission_provider = registry.lookup([IPermission], IPermissionSource, value)
+        perm_grant_provider = registry.lookup([IPermissionGrant], IPermissionGrantSource, value)
 
-        if not (identity_provider or auth_session or permission_provider):
+        if not (identity_provider or auth_session or permission_provider or perm_grant_provider):
             request.errors.add(
                 location='path',
                 name='realm_slug',
@@ -33,6 +35,11 @@ class BasePathSchema(marshmallow.Schema):
             logger.info('Realm %s is not valid.', request.context.realm)
             return
 
+        request.identity_provider = identity_provider
         request.auth_session = auth_session
         request.permission_provider = permission_provider
-        request.identity_provider = identity_provider
+        request.perm_grant_provider = perm_grant_provider
+
+
+class PermissionGrantPathSchema(BasePathSchema):
+    perm_grant_id = marshmallow.fields.UUID()

--- a/keyloop/schemas/path.py
+++ b/keyloop/schemas/path.py
@@ -4,6 +4,7 @@ import marshmallow
 
 from keyloop.interfaces.auth_session import IAuthSession, IAuthSessionSource
 from keyloop.interfaces.identity import IIdentity, IIdentitySource
+from keyloop.interfaces.permission import IPermission, IPermissionSource
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +21,9 @@ class BasePathSchema(marshmallow.Schema):
 
         identity_provider = registry.lookup([IIdentity], IIdentitySource, value)
         auth_session = registry.lookup([IAuthSession], IAuthSessionSource, value)
+        permission_provider = registry.lookup([IPermission], IPermissionSource, value)
 
-        if not (identity_provider or auth_session):
+        if not (identity_provider or auth_session or permission_provider):
             request.errors.add(
                 location='path',
                 name='realm_slug',
@@ -32,4 +34,5 @@ class BasePathSchema(marshmallow.Schema):
             return
 
         request.auth_session = auth_session
+        request.permission_provider = permission_provider
         request.identity_provider = identity_provider

--- a/keyloop/schemas/permission.py
+++ b/keyloop/schemas/permission.py
@@ -1,0 +1,12 @@
+import marshmallow_jsonapi
+from marshmallow import fields
+
+
+class PermissionSchema(marshmallow_jsonapi.Schema):
+    class Meta:
+        type_ = "permission"
+
+    id = fields.UUID(dump_only=True, attribute="uuid")
+
+    name = fields.String(required=True)
+    description = fields.String(required=True, validate=lambda x: True if x != "" else False)

--- a/keyloop/schemas/permission.py
+++ b/keyloop/schemas/permission.py
@@ -7,6 +7,13 @@ class PermissionSchema(marshmallow_jsonapi.Schema):
         type_ = "permission"
 
     id = fields.UUID(dump_only=True, attribute="uuid")
-
     name = fields.String(required=True)
-    description = fields.String(required=True, validate=lambda x: True if x != "" else False)
+    description = fields.String(required=True, validate=lambda x: True if x != "" else False)  # Empty string not acceptable
+
+
+class PermissionGrantSchema(marshmallow_jsonapi.Schema):
+    class Meta:
+        type_ = "permission-grant"
+
+    id = fields.UUID(dump_only=True, attribute="uuid")
+    perm_name = fields.String(required=True)

--- a/keyloop/schemas/permission.py
+++ b/keyloop/schemas/permission.py
@@ -1,14 +1,31 @@
 import marshmallow_jsonapi
+import marshmallow
 from marshmallow import fields
 
 
-class PermissionSchema(marshmallow_jsonapi.Schema):
+class BaseSchema(marshmallow_jsonapi.Schema):
     class Meta:
         type_ = "permission"
 
     id = fields.UUID(dump_only=True, attribute="uuid")
+
+
+class PermissionSchema(BaseSchema):
     name = fields.String(required=True)
-    description = fields.String(required=True, validate=lambda x: True if x != "" else False)  # Empty string not accepted
+    description = fields.String(required=True,
+                                validate=lambda x: True if x != "" else False)  # Empty string not accepted
+
+
+class PermissionQueryStringSchema(marshmallow.Schema):
+    page = fields.Integer(validate=lambda x: True if x > 0 else False,
+                          load_from="page[number]")  # Only number great than zero
+    limit = fields.Integer(validate=lambda x: True if x > 0 else False,
+                           load_from="page[size]")  # Only number great than zero
+
+
+class PermissionsListSchema(BaseSchema):
+    items = fields.List(fields.Nested(PermissionSchema))
+    document_meta = marshmallow_jsonapi.fields.DocumentMeta(required=False)
 
 
 class PermissionGrantSchema(marshmallow_jsonapi.Schema):

--- a/keyloop/schemas/permission.py
+++ b/keyloop/schemas/permission.py
@@ -8,7 +8,7 @@ class PermissionSchema(marshmallow_jsonapi.Schema):
 
     id = fields.UUID(dump_only=True, attribute="uuid")
     name = fields.String(required=True)
-    description = fields.String(required=True, validate=lambda x: True if x != "" else False)  # Empty string not acceptable
+    description = fields.String(required=True, validate=lambda x: True if x != "" else False)  # Empty string not accepted
 
 
 class PermissionGrantSchema(marshmallow_jsonapi.Schema):

--- a/keyloop/utils/__init__.py
+++ b/keyloop/utils/__init__.py
@@ -1,0 +1,5 @@
+import uuid
+
+
+def generate_uuid():
+    return uuid.uuid4()

--- a/playground/main.py
+++ b/playground/main.py
@@ -10,6 +10,7 @@ def main():
         "sqlalchemy.url": "sqlite:///keyloop.dev",
         "keyloop.identity_sources": "PLAYGROUND:keyloop.ext.sqla.identity.IdentitySource",
         "keyloop.auth_session_sources": "PLAYGROUND:keyloop.ext.sqla.auth_session.AuthSessionSource",
+        "keyloop.permission_sources": "PLAYGROUND:keyloop.ext.sqla.permission.PermissionSource",
         "keyloop.authpolicysecret": "sekret",
     }
 
@@ -29,6 +30,7 @@ def main():
         })
 
         app = config.make_wsgi_app()
+
     return app
 
 

--- a/playground/main.py
+++ b/playground/main.py
@@ -2,7 +2,8 @@ from wsgiref.simple_server import make_server
 
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
-from playground.models import Base, DBSession, RealIdentity
+
+from playground.models import Base, DBSession, RealIdentity, RealPermission
 
 
 def main():
@@ -26,7 +27,8 @@ def main():
 
         config.key_loop_setup(DBSession, {
             'IdentitySource': RealIdentity,
-            'AuthSessionSource': RealIdentity
+            'AuthSessionSource': RealIdentity,
+            'PermissionSource': RealPermission
         })
 
         app = config.make_wsgi_app()

--- a/playground/manage.py
+++ b/playground/manage.py
@@ -1,4 +1,5 @@
 import logging
+
 import click
 import transaction
 

--- a/playground/models.py
+++ b/playground/models.py
@@ -1,8 +1,10 @@
-from sqlalchemy.ext.declarative import declarative_base
+import sqlalchemy  as sa
+from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import (
     scoped_session,
     sessionmaker,
-)
+    relationship)
+from sqlalchemy_utils import UUIDType
 from zope.sqlalchemy import register
 
 from keyloop.ext.sqla.identity import Identity
@@ -12,11 +14,18 @@ DBSession = scoped_session(sessionmaker())
 register(DBSession)
 Base = declarative_base()
 
+permission_grant_table = sa.Table(
+    'permission_grant', Base.metadata,
+    sa.Column('identity_id', UUIDType, sa.ForeignKey('identity.id')),
+    sa.Column('permission_id', sa.Integer, sa.ForeignKey('permission.id'))
+)
+
 
 class RealIdentity(Identity, Base):
-    pass
+    @declared_attr
+    def permissions(self):
+        return relationship("RealPermission", secondary=permission_grant_table)
 
 
 class RealPermission(Permission, Base):
     pass
-

--- a/playground/models.py
+++ b/playground/models.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import (
 from zope.sqlalchemy import register
 
 from keyloop.ext.sqla.identity import Identity
+from keyloop.ext.sqla.permission import Permission
 
 DBSession = scoped_session(sessionmaker())
 register(DBSession)
@@ -14,3 +15,8 @@ Base = declarative_base()
 
 class RealIdentity(Identity, Base):
     pass
+
+
+class RealPermission(Permission, Base):
+    pass
+

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requires = [
     "cornice-apispec==0.9.3",
     "click",
     "cryptacular==1.5.5",
+    "sqlalchemy-pagination==0.0.2",
 ]
 
 test_requires = [

--- a/tests/api/v1/test_identity.py
+++ b/tests/api/v1/test_identity.py
@@ -180,7 +180,7 @@ def test_update_error_identity(pyramid_app, identity_payload, fake_user_class):
     }
 
 
-def test_update_identity_password(pyramid_app, identity_payload, fakeUserClass):
+def test_update_identity_password(pyramid_app, identity_payload, fake_user_class):
     pyramid_app.post_json("/api/v1/realms/REALM/identities", identity_payload,
                           content_type="application/vnd.api+json", status=200, )
 
@@ -194,15 +194,15 @@ def test_update_identity_password(pyramid_app, identity_payload, fakeUserClass):
         }
     }
 
-    pyramid_app.patch_json("/api/v1/realms/REALM/identities/1bed6e99-74d8-484a-a650-fab8f4f80506/password",
+    identity_id = str(next(iter(fake_user_class.IDENTITIES.keys())))
+    pyramid_app.patch_json(f"/api/v1/realms/REALM/identities/{identity_id}/password",
                            params,
                            content_type="application/vnd.api+json", status=204, )
 
-    assert fakeUserClass.IDENTITIES['1bed6e99-74d8-484a-a650-fab8f4f80506']['password'] == \
-           params["data"]["attributes"]["password"]
+    assert fake_user_class.IDENTITIES[identity_id]['password'] == params["data"]["attributes"]["password"]
 
 
-def test_update_identity_password_user_not_found(pyramid_app, identity_payload, fakeUserClass):
+def test_update_identity_password_user_not_found(pyramid_app, identity_payload, fake_user_class):
     pyramid_app.post_json("/api/v1/realms/REALM/identities", identity_payload,
                           content_type="application/vnd.api+json", status=200, )
 
@@ -232,7 +232,7 @@ def test_update_identity_password_user_not_found(pyramid_app, identity_payload, 
     }
 
 
-def test_update_identity_password_authentucation_failed(pyramid_app, identity_payload, fakeUserClass):
+def test_update_identity_password_authentucation_failed(pyramid_app, identity_payload, fake_user_class):
     pyramid_app.post_json("/api/v1/realms/REALM/identities", identity_payload,
                           content_type="application/vnd.api+json", status=200, )
 
@@ -246,7 +246,8 @@ def test_update_identity_password_authentucation_failed(pyramid_app, identity_pa
         }
     }
 
-    res = pyramid_app.patch_json("/api/v1/realms/REALM/identities/1bed6e99-74d8-484a-a650-fab8f4f80506/password",
+    identity_id = str(next(iter(fake_user_class.IDENTITIES.keys())))
+    res = pyramid_app.patch_json(f"/api/v1/realms/REALM/identities/{identity_id}/password",
                                  params,
                                  content_type="application/vnd.api+json", status=401, )
 

--- a/tests/api/v1/test_permission.py
+++ b/tests/api/v1/test_permission.py
@@ -28,7 +28,7 @@ def test_create_permission(pyramid_app, permission_payload):
                 "name": "permission_a",
                 "description": "Permission for resource A"
             }
-        }
+        },
     }
 
 
@@ -91,6 +91,83 @@ def test_create_permission_with_invalid_realm(pyramid_app, permission_payload):
                 "location": "path",
                 "name": "realm_slug",
                 "description": "Invalid realm"
+            }
+        ]
+    }
+
+
+def test_get_permissions_empty_list(pyramid_app, permission_payload, fake_permission_class):
+    res = pyramid_app.get("/api/v1/realms/REALM/permissions", params={'page[number]': 2, 'page[size]': 30})
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {'data': None}
+
+
+def test_get_permissions(pyramid_app, permission_payload, fake_permission_class):
+    pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,
+                          content_type="application/vnd.api+json",
+                          status=200)
+
+    res = pyramid_app.get("/api/v1/realms/REALM/permissions", params={'page[number]': 1, 'page[size]': 30})
+
+    permission_id = str(next(iter(fake_permission_class.PERMISSIONS.keys())))
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "data": {
+            "type": "permission",
+            "attributes": {
+                "items": [
+                    {
+                        "data": {
+                            "type": "permission",
+                            "attributes": {
+                                "name": "permission_a",
+                                "description": "Permission for resource A"
+                            },
+                            "id": permission_id
+                        }
+                    }
+                ]
+            }
+        },
+        "meta": {
+            "page": 1,
+            "total": 1
+        }
+    }
+
+
+def test_get_permissions_negative_page(pyramid_app, permission_payload):
+    res = pyramid_app.get("/api/v1/realms/REALM/permissions", params={'page[number]': -1, 'page[size]': 30}, status=400)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "status": "error",
+        "errors": [
+            {
+                "location": "querystring",
+                "name": "page[number]",
+                "description": [
+                    "Invalid value."
+                ]
+            }
+        ]
+    }
+
+
+def test_get_permissions_negative_limit(pyramid_app, permission_payload):
+    res = pyramid_app.get("/api/v1/realms/REALM/permissions", params={'page[number]': 1, 'page[size]': -30}, status=400)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "status": "error",
+        "errors": [
+            {
+                "location": "querystring",
+                "name": "page[size]",
+                "description": [
+                    "Invalid value."
+                ]
             }
         ]
     }

--- a/tests/api/v1/test_permission.py
+++ b/tests/api/v1/test_permission.py
@@ -1,0 +1,74 @@
+import pytest
+
+
+@pytest.fixture
+def permission_payload():
+    return {
+        "data": {
+            "type": "permission",
+            "attributes": {
+                "name": "permission_a",
+                "description": "Permission for resource A"
+            }
+        }
+    }
+
+
+def test_create_permission(pyramid_app, permission_payload):
+    res = pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,
+                                content_type="application/vnd.api+json",
+                                status=200)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "data": {
+            "id": res.json['data']['id'],
+            "type": "permission",
+            "attributes": {
+                "name": "permission_a",
+                "description": "Permission for resource A"
+            }
+        }
+    }
+
+
+def test_create_permission_with_invalid_data(pyramid_app, permission_payload):
+    permission_payload['data']['attributes']['description'] = ''
+    res = pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,
+                                content_type="application/vnd.api+json",
+                                status=400)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "status": "error",
+        "errors": [
+            {
+                "location": "body",
+                "name": "errors",
+                "description": [
+                    {
+                        "detail": "Invalid value.",
+                        "source": {"pointer": "/data/attributes/description"}
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_create_permission_with_invalid_realm(pyramid_app, permission_payload):
+    res = pyramid_app.post_json("/api/v1/realms/INVALID-REALM/permissions", permission_payload,
+                                content_type="application/vnd.api+json",
+                                status=404)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "status": "error",
+        "errors": [
+            {
+                "location": "path",
+                "name": "realm_slug",
+                "description": "Invalid realm"
+            }
+        ]
+    }

--- a/tests/api/v1/test_permission.py
+++ b/tests/api/v1/test_permission.py
@@ -32,6 +32,28 @@ def test_create_permission(pyramid_app, permission_payload):
     }
 
 
+def test_create_permission_with_existent_name(pyramid_app, permission_payload, fake_permission_class):
+    pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,
+                          content_type="application/vnd.api+json",
+                          status=200)
+
+    res = pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,
+                                content_type="application/vnd.api+json",
+                                status=400)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "status": "error",
+        "errors": [
+            {
+                "location": "body",
+                "name": "name",
+                "description": "Existent permission with name: permission_a"
+            }
+        ]
+    }
+
+
 def test_create_permission_with_invalid_data(pyramid_app, permission_payload):
     permission_payload['data']['attributes']['description'] = ''
     res = pyramid_app.post_json("/api/v1/realms/REALM/permissions", permission_payload,

--- a/tests/api/v1/test_permission_grant.py
+++ b/tests/api/v1/test_permission_grant.py
@@ -20,12 +20,13 @@ def perm_grant_payload():
 
 class TestGrantPermission:
 
-    def test_grant_permission_success(self, pyramid_app, perm_grant_payload, user, permission, fake_perm_grant_class):
+    def test_grant_permission_success(self, pyramid_app, perm_grant_payload, user, permission):
         res = pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{user.id}/permissions",
                                     perm_grant_payload,
                                     content_type="application/vnd.api+json",
                                     status=200)
 
+        assert (str(permission.uuid), str(user.id)) in user.PERMISSION_GRANTS
         assert res.content_type == "application/vnd.api+json"
         assert res.json == {
             "data": {
@@ -39,7 +40,8 @@ class TestGrantPermission:
         }
 
     def test_identity_not_found(self, pyramid_app, perm_grant_payload, user):
-        res = pyramid_app.post_json("/api/v1/realms/REALM/identities/9f533cff-a6b3-4430-b1b9-557da85e0121/permissions",
+        inexistent_identity_id = "9f533cff-a6b3-4430-b1b9-557da85e0121"
+        res = pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{inexistent_identity_id}/permissions",
                                     perm_grant_payload,
                                     content_type="application/vnd.api+json",
                                     status=404)
@@ -52,6 +54,49 @@ class TestGrantPermission:
                     "location": "path",
                     "name": "identity_id",
                     "description": "Identity not found"
+                }
+            ]
+        }
+
+    def test_permission_not_found(self, pyramid_app, perm_grant_payload, user):
+        perm_grant_payload["data"]["attributes"]["perm_name"] = "crazy-permission"
+        res = pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{user.id}/permissions",
+                                    perm_grant_payload,
+                                    content_type="application/vnd.api+json",
+                                    status=400)
+
+        assert res.content_type == "application/vnd.api+json"
+        assert res.json == {
+            "status": "error",
+            "errors": [
+                {
+                    "location": "body",
+                    "name": "perm_name",
+                    "description": "Permission not found"
+                }
+            ]
+        }
+
+    def test_permission_already_granted_to_identity(self, pyramid_app, perm_grant_payload, user, permission):
+        pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{user.id}/permissions",
+                              perm_grant_payload,
+                              content_type="application/vnd.api+json",
+                              status=200)
+
+        assert {(str(permission.uuid), str(user.id))} == user.PERMISSION_GRANTS
+
+        res = pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{user.id}/permissions",
+                                    perm_grant_payload,
+                                    content_type="application/vnd.api+json",
+                                    status=400)
+        assert res.content_type == "application/vnd.api+json"
+        assert res.json == {
+            "status": "error",
+            "errors": [
+                {
+                    "location": "body",
+                    "name": "perm_name",
+                    "description": "Permission already granted to identity"
                 }
             ]
         }

--- a/tests/api/v1/test_permission_grant.py
+++ b/tests/api/v1/test_permission_grant.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+@pytest.fixture
+def identity(fakeUserClass):
+    return fakeUserClass.create('test@test.com.br', '1234567a', 'Test', [])
+
+
+@pytest.fixture
+def permission(fake_permission_class):
+    return fake_permission_class.create(name='perm_a', description='Permission for service A.')
+
+
+@pytest.fixture
+def perm_grant_payload():
+    return {
+        "data": {
+            "type": "permission-grant",
+            "attributes": {
+                "perm_name": "perm_a",
+            }
+        }
+    }
+
+
+def test_create_permission_grant(pyramid_app, perm_grant_payload, identity, permission, fake_perm_grant_class):
+    res = pyramid_app.post_json(f"/api/v1/realms/REALM/identities/{identity.id}/permissions",
+                                perm_grant_payload,
+                                content_type="application/vnd.api+json",
+                                status=200)
+
+    assert res.content_type == "application/vnd.api+json"
+    assert res.json == {
+        "data": {
+            "type": "permission-grant",
+            "id": str(next(iter(fake_perm_grant_class.PERMISSION_GRANTS)))
+        }
+    }

--- a/tests/api/v1/test_permission_grant.py
+++ b/tests/api/v1/test_permission_grant.py
@@ -29,8 +29,12 @@ class TestGrantPermission:
         assert res.content_type == "application/vnd.api+json"
         assert res.json == {
             "data": {
-                "type": "permission-grant",
-                "id": str(next(iter(fake_perm_grant_class.PERMISSION_GRANTS)))
+                "type": "permission",
+                "attributes": {
+                    "description": "Permission for service A.",
+                    "name": "perm_a"
+                },
+                "id": str(permission.uuid)
             }
         }
 
@@ -46,7 +50,7 @@ class TestGrantPermission:
             "errors": [
                 {
                     "location": "path",
-                    "name": "identity_get",
+                    "name": "identity_id",
                     "description": "Identity not found"
                 }
             ]

--- a/tests/api/v1/test_permission_grant.py
+++ b/tests/api/v1/test_permission_grant.py
@@ -2,8 +2,8 @@ import pytest
 
 
 @pytest.fixture
-def identity(fakeUserClass):
-    return fakeUserClass.create('test@test.com.br', '1234567a', 'Test', [])
+def identity(fake_user_class):
+    return fake_user_class.create('test@test.com.br', '1234567a', 'Test', [])
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ def pyramid_config():
             "keyloop.identity_sources": "REALM:tests.fake_user.FakeUser",
             "keyloop.auth_session_sources": "REALM:tests.fake_auth_session.FakeAuthSession",
             "keyloop.permission_sources": "REALM:tests.fake_permission.FakePermission",
-            "keyloop.perm_grant_sources": "REALM:tests.fake_permission.FakePermissionGrant",
             "keyloop.authpolicysecret": "sekret"
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def pyramid_config():
             "keyloop.identity_sources": "REALM:tests.fake_user.FakeUser",
             "keyloop.auth_session_sources": "REALM:tests.fake_auth_session.FakeAuthSession",
             "keyloop.permission_sources": "REALM:tests.fake_permission.FakePermission",
+            "keyloop.perm_grant_sources": "REALM:tests.fake_permission.FakePermissionGrant",
             "keyloop.authpolicysecret": "sekret"
         }
     )
@@ -41,3 +42,17 @@ def fakeAuthSessionClass():
     FakeAuthSession.test_reset()
 
     yield FakeAuthSession
+
+
+@pytest.fixture
+def fake_permission_class():
+    from tests.fake_permission import FakePermission
+    FakePermission.test_reset()
+    yield FakePermission
+
+
+@pytest.fixture
+def fake_perm_grant_class():
+    from tests.fake_permission import FakePermissionGrant
+    FakePermissionGrant.test_reset()
+    yield FakePermissionGrant

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,20 +27,22 @@ def pyramid_app(pyramid_config):
 
 
 @pytest.fixture
-def fakeUserClass():
+def fake_user_class():
     from tests.fake_user import FakeUser
-
     FakeUser.test_reset()
-
     yield FakeUser
 
 
 @pytest.fixture
-def fakeAuthSessionClass():
+def user(fake_user_class):
+    user = fake_user_class.create('test@test.com.br', '1234567a')
+    return user
+
+
+@pytest.fixture
+def fake_auth_session_class():
     from tests.fake_auth_session import FakeAuthSession
-
     FakeAuthSession.test_reset()
-
     yield FakeAuthSession
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ def pyramid_config():
         settings={
             "keyloop.identity_sources": "REALM:tests.fake_user.FakeUser",
             "keyloop.auth_session_sources": "REALM:tests.fake_auth_session.FakeAuthSession",
+            "keyloop.permission_sources": "REALM:tests.fake_permission.FakePermission",
             "keyloop.authpolicysecret": "sekret"
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,10 +51,3 @@ def fake_permission_class():
     from tests.fake_permission import FakePermission
     FakePermission.test_reset()
     yield FakePermission
-
-
-@pytest.fixture
-def fake_perm_grant_class():
-    from tests.fake_permission import FakePermissionGrant
-    FakePermissionGrant.test_reset()
-    yield FakePermissionGrant

--- a/tests/fake_auth_session.py
+++ b/tests/fake_auth_session.py
@@ -1,18 +1,15 @@
-import uuid
-
 import arrow
 
 from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed
+from keyloop.utils import generate_uuid
 
 
 class FakeAuthSession:
-
     test_delete_called = False
-    generated_uuid = uuid.uuid4()
-    identity = {}
+    identity = None
 
-    def __init__(self, identity, active, ttl, start, id):
-        self.uuid = id
+    def __init__(self, identity, active, ttl, start, uuid=None):
+        self.uuid = uuid if uuid else generate_uuid()
         self.identity = identity
         self.identity_id = identity.id
         self.active = active
@@ -28,18 +25,17 @@ class FakeAuthSession:
         if not username:
             raise IdentityNotFound
 
-        return cls(cls.identity, True, 600, arrow.utcnow().datetime, cls.generated_uuid)
+        return cls(cls.identity, True, 600, arrow.utcnow().datetime)
 
     @classmethod
     def login(cls, username, password):
         from tests.fake_user import FakeUser
-        cls.identity = FakeUser(username='test@test.com.br', password='1234567a')
-        cls.identity.uuid = uuid.uuid4()
+        cls.identity = FakeUser.get(username=username)
 
-        if username != cls.identity.username:
+        if not cls.identity:
             raise IdentityNotFound
 
         if password != cls.identity.password:
             raise AuthenticationFailed
 
-        return cls(cls.identity, True, 600, arrow.utcnow().datetime, cls.generated_uuid)
+        return cls(cls.identity, True, 600, arrow.utcnow().datetime)

--- a/tests/fake_auth_session.py
+++ b/tests/fake_auth_session.py
@@ -30,7 +30,7 @@ class FakeAuthSession:
     @classmethod
     def login(cls, username, password):
         from tests.fake_user import FakeUser
-        cls.identity = FakeUser.get(username=username)
+        cls.identity = FakeUser.get_by(username=username)
 
         if not cls.identity:
             raise IdentityNotFound

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -1,0 +1,20 @@
+from keyloop.utils import generate_uuid
+
+
+class FakePermission:
+    PERMISSIONS = {}
+
+    def __init__(self, name, description):
+        self.uuid = generate_uuid()
+        self.name = name
+        self.description = description
+
+    @classmethod
+    def test_reset(cls):
+        cls.PERMISSIONS = {}
+
+    @classmethod
+    def create(cls, name, description):
+        permission = cls(name, description)
+        cls.PERMISSIONS.update({permission.uuid: permission.__dict__})
+        return permission

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -5,10 +5,11 @@ from keyloop.utils import generate_uuid
 class FakePermission:
     PERMISSIONS = {}
 
-    def __init__(self, name, description, uuid=None):
+    def __init__(self, name, description, uuid=None, document_meta=None):
         self.uuid = uuid if uuid else generate_uuid()
         self.name = name
         self.description = description
+        self.document_meta = document_meta
 
     @classmethod
     def test_reset(cls):
@@ -42,3 +43,15 @@ class FakePermission:
             return permission
         else:
             raise PermissionAlreadyExists
+
+    @classmethod
+    def list(cls, page, limit):
+        params = []
+        limit = len(cls.PERMISSIONS) if limit > len(cls.PERMISSIONS) else limit
+        current_page = 0 if page in (0, 1) else page
+
+        if not cls.PERMISSIONS:
+            return params
+
+        params.append(list(cls.PERMISSIONS.items())[0][1])
+        return {'items': params[current_page:limit], 'document_meta': {'page': page, 'total': len(cls.PERMISSIONS)}}

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -54,7 +54,7 @@ class FakePermissionGrant:
         return cls.PERMISSION_GRANTS.get(uuid)
 
     @classmethod
-    def create(cls, permission_id, identity_id):
+    def grant_permission(cls, permission_id, identity_id):
         perm_ident_assoc = (permission_id, identity_id)
         if perm_ident_assoc in cls.PERM_IDENT_ASSOCIATIONS:
             raise PermissionGrantAlreadyExists

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -25,9 +25,9 @@ class FakePermission:
 
     @classmethod
     def get_by(cls, **kwargs):
-        if 'name' in kwargs.keys():
+        if 'name' in kwargs:
             return cls._get_by_name(kwargs['name'])
-        elif 'uuid' in kwargs.keys():
+        elif 'uuid' in kwargs:
             params = cls.PERMISSIONS.get(kwargs['uuid'])
             if not params:
                 raise PermissionNotFound()

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -1,4 +1,4 @@
-from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionGrantAlreadyExists
+from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionGrantAlreadyExists, PermissionNotFound
 from keyloop.utils import generate_uuid
 
 
@@ -15,14 +15,21 @@ class FakePermission:
         cls.PERMISSIONS = {}
 
     @classmethod
-    def get(cls, uuid=None, name=None):
-        if name:
-            for perm in cls.PERMISSIONS.values():
-                if perm['name'] == name:
-                    return cls(**perm)
+    def _get_by_name(cls, name):
+        for perm in cls.PERMISSIONS.values():
+            if perm['name'] == name:
+                return cls(**perm)
 
-        params = cls.PERMISSIONS.get(uuid)
-        if params:
+        raise PermissionNotFound()
+
+    @classmethod
+    def get_by(cls, **kwargs):
+        if 'name' in kwargs.keys():
+            return cls._get_by_name(kwargs['name'])
+        elif 'uuid' in kwargs.keys():
+            params = cls.PERMISSIONS.get(kwargs['uuid'])
+            if not params:
+                raise PermissionNotFound()
             return cls(**params)
 
     @classmethod

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -1,4 +1,4 @@
-from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionAlreadyGranted, PermissionNotFound
+from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionNotFound
 from keyloop.utils import generate_uuid
 
 
@@ -42,33 +42,3 @@ class FakePermission:
             return permission
         else:
             raise PermissionAlreadyExists
-
-
-class FakePermissionGrant:
-    PERMISSION_GRANTS = {}
-    PERM_IDENT_ASSOCIATIONS = set()
-
-    def __init__(self, permission_id, identity_id):
-        self.uuid = generate_uuid()
-        self.permission_id = permission_id
-        self.identity_id = identity_id
-
-    @classmethod
-    def test_reset(cls):
-        cls.PERMISSION_GRANTS = {}
-        cls.PERM_IDENT_ASSOCIATIONS = set()
-
-    @classmethod
-    def get(cls, uuid):
-        return cls.PERMISSION_GRANTS.get(uuid)
-
-    @classmethod
-    def grant_permission(cls, permission_id, identity_id):
-        perm_ident_assoc = (permission_id, identity_id)
-        if perm_ident_assoc in cls.PERM_IDENT_ASSOCIATIONS:
-            raise PermissionAlreadyGranted
-
-        permission_grant = cls(*perm_ident_assoc)
-        cls.PERMISSION_GRANTS.update({permission_grant.uuid: permission_grant.__dict__})
-        cls.PERM_IDENT_ASSOCIATIONS.add(perm_ident_assoc)
-        return permission_grant

--- a/tests/fake_permission.py
+++ b/tests/fake_permission.py
@@ -1,11 +1,12 @@
+from keyloop.api.v1.exceptions import PermissionAlreadyExists, PermissionGrantAlreadyExists
 from keyloop.utils import generate_uuid
 
 
 class FakePermission:
     PERMISSIONS = {}
 
-    def __init__(self, name, description):
-        self.uuid = generate_uuid()
+    def __init__(self, name, description, uuid=None):
+        self.uuid = uuid if uuid else generate_uuid()
         self.name = name
         self.description = description
 
@@ -14,7 +15,51 @@ class FakePermission:
         cls.PERMISSIONS = {}
 
     @classmethod
+    def get(cls, uuid=None, name=None):
+        if name:
+            for perm in cls.PERMISSIONS.values():
+                if perm['name'] == name:
+                    return cls(**perm)
+
+        params = cls.PERMISSIONS.get(uuid)
+        if params:
+            return cls(**params)
+
+    @classmethod
     def create(cls, name, description):
+        if cls.get(name=name):
+            raise PermissionAlreadyExists
+
         permission = cls(name, description)
         cls.PERMISSIONS.update({permission.uuid: permission.__dict__})
         return permission
+
+
+class FakePermissionGrant:
+    PERMISSION_GRANTS = {}
+    PERM_IDENT_ASSOCIATIONS = set()
+
+    def __init__(self, permission_id, identity_id):
+        self.uuid = generate_uuid()
+        self.permission_id = permission_id
+        self.identity_id = identity_id
+
+    @classmethod
+    def test_reset(cls):
+        cls.PERMISSION_GRANTS = {}
+        cls.PERM_IDENT_ASSOCIATIONS = set()
+
+    @classmethod
+    def get(cls, uuid):
+        return cls.PERMISSION_GRANTS.get(uuid)
+
+    @classmethod
+    def create(cls, permission_id, identity_id):
+        perm_ident_assoc = (permission_id, identity_id)
+        if perm_ident_assoc in cls.PERM_IDENT_ASSOCIATIONS:
+            raise PermissionGrantAlreadyExists
+
+        permission_grant = cls(*perm_ident_assoc)
+        cls.PERMISSION_GRANTS.update({permission_grant.uuid: permission_grant.__dict__})
+        cls.PERM_IDENT_ASSOCIATIONS.add(perm_ident_assoc)
+        return permission_grant

--- a/tests/fake_user.py
+++ b/tests/fake_user.py
@@ -32,9 +32,9 @@ class FakeUser:
 
     @classmethod
     def get_by(cls, **kwargs):
-        if 'username' in kwargs.keys():
+        if 'username' in kwargs:
             return cls._get_by_username(kwargs['username'])
-        elif 'uuid' in kwargs.keys():
+        elif 'uuid' in kwargs:
             params = cls.IDENTITIES.get(str(kwargs['uuid']))
             if not params:
                 raise IdentityNotFound()

--- a/tests/fake_user.py
+++ b/tests/fake_user.py
@@ -22,14 +22,21 @@ class FakeUser:
         cls.IDENTITIES = {}
 
     @classmethod
-    def get(cls, uuid=None, username=None):
-        if username:
-            for params in cls.IDENTITIES.values():
-                if params['username'] == username:
-                    return cls(**params)
+    def _get_by_username(cls, username):
+        for params in cls.IDENTITIES.values():
+            if params['username'] == username:
+                return cls(**params)
 
-        params = cls.IDENTITIES.get(str(uuid))
-        if params:
+        raise IdentityNotFound()
+
+    @classmethod
+    def get_by(cls, **kwargs):
+        if 'username' in kwargs.keys():
+            return cls._get_by_username(kwargs['username'])
+        elif 'uuid' in kwargs.keys():
+            params = cls.IDENTITIES.get(str(kwargs['uuid']))
+            if not params:
+                raise IdentityNotFound()
             return cls(**params)
 
     @classmethod

--- a/tests/fake_user.py
+++ b/tests/fake_user.py
@@ -1,16 +1,21 @@
 from keyloop.api.v1.exceptions import IdentityNotFound, AuthenticationFailed
+from keyloop.utils import generate_uuid
 
 
 class FakeUser:
     IDENTITIES = {}
 
-    def __init__(self, username, password, active=True, name=None):
-        self.id = '1bed6e99-74d8-484a-a650-fab8f4f80506'
+    test_delete_result = True
+    test_delete_called = False
+
+    def __init__(self, username, password, active=True, name=None, contacts=None, id=None, permissions=None):
+        # self.id = '1bed6e99-74d8-484a-a650-fab8f4f80506'
+        self.id = id if id else generate_uuid()
         self.username = username
         self.password = password
         self.name = name
         self.active = active
-        self.permissions = ['perm_a', 'perm_b', 'perm_c']
+        self.permissions = permissions if permissions else ['perm_a', 'perm_b', 'perm_c']
 
     @classmethod
     def test_reset(cls):
@@ -18,21 +23,18 @@ class FakeUser:
 
     @classmethod
     def get(cls, uuid):
-        identity = cls('test@test.com.br', password="1234567a")
-        identity.uuid = uuid
-        return identity
+        params = cls.IDENTITIES.get(uuid)
+        return cls(**params)
 
     @classmethod
-    def create(cls, username, password, name):
-        params = {
-            'username': username,
-            'password': password,
-            'active': True,
-            'name': name,
-        }
+    def create(cls, username, password, name, contacts):
+        identity = cls(username, password, True, name, contacts)
+        cls.IDENTITIES.update({identity.id: identity.__dict__})
+        return identity
 
-        cls.IDENTITIES.update({'1bed6e99-74d8-484a-a650-fab8f4f80506': params})
-        return cls(username, password, True, name)
+    def login(self, username, password):
+        self.__class__.test_login_called = True
+        return self.__class__.test_login_result
 
     @classmethod
     def delete(cls, identity_id):

--- a/tests/fake_user.py
+++ b/tests/fake_user.py
@@ -22,14 +22,20 @@ class FakeUser:
         cls.IDENTITIES = {}
 
     @classmethod
-    def get(cls, uuid):
-        params = cls.IDENTITIES.get(uuid)
-        return cls(**params)
+    def get(cls, uuid=None, username=None):
+        if username:
+            for params in cls.IDENTITIES.values():
+                if params['username'] == username:
+                    return cls(**params)
+
+        params = cls.IDENTITIES.get(str(uuid))
+        if params:
+            return cls(**params)
 
     @classmethod
-    def create(cls, username, password, name, contacts):
+    def create(cls, username, password, name=None, contacts=None):
         identity = cls(username, password, True, name, contacts)
-        cls.IDENTITIES.update({identity.id: identity.__dict__})
+        cls.IDENTITIES.update({str(identity.id): identity.__dict__})
         return identity
 
     def login(self, username, password):

--- a/tests/fake_user.py
+++ b/tests/fake_user.py
@@ -74,3 +74,7 @@ class FakeUser:
             raise AuthenticationFailed()
 
         identity['password'] = password
+
+    @classmethod
+    def grant_permission(cls, permission, identity):
+        pass


### PR DESCRIPTION
**Story:** [MERCHANTS-10](https://geruteam.atlassian.net/browse/MERCHANTS-10)
**Subtask:** [MERCHANTS-14](https://geruteam.atlassian.net/browse/MERCHANTS-14)

**Changes:**
-
- Remove fixed `id` in `FakeUser` and its tests
- Add endpoint POST `/realms/{realm_slug}/identities/{id}/permissions` to register a permission;
- Add endpoint POST `/realms/{realm_slug}/identities/{id}/permissions/{perm_grant_id}` to grant permission to some identity. In case of success, returns the same schema of permission creation;
- Implement both endpoints in `playground`.